### PR TITLE
Significantly improve annotate_tips performance

### DIFF
--- a/clusterfunk/utilities/treeAnnotator.py
+++ b/clusterfunk/utilities/treeAnnotator.py
@@ -39,8 +39,10 @@ class TreeAnnotator:
             self.add_boolean(node, trait, boolean_trait_name, regex)
 
     def annotate_tips(self, annotations):
-        for tip_label in annotations:
-            self.annotate_node(tip_label, annotations[tip_label])
+        for node in self.tree.leaf_node_iter():
+            for ak, av in annotations.get(node.taxon.label, {}).items():
+                if av and (type(av) is str and len(av) > 0) or type(av) is not str:
+                    safeNodeAnnotator.annotate(node, ak, check_str_for_bool(av))
 
     def add_boolean(self, node, trait, boolean_trait_name, regex):
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
         name="clusterfunk",
-        version="0.0.2",
+        version="0.0.3",
         packages=find_packages(),
         url="https://github.com/cov-ert/clusterfunk",
         license="MIT",


### PR DESCRIPTION
The current implementation of annotate_tips calls annotate_node for each
annotation in the metadata structure. However, annotate_node calls
find_node_with_taxon which has a performance complexity that increases
with the size of the tree. For very large, complex trees, the amount
of time spent searching the tree with this function becomes significant.

This commit replaces the implementation of annotate_tips such that it
no longer calls annotate_node to perform a search. Instead, annotate_tips
now iterates through the nodes in the tree with leaf_node_iter and checks
to see if the node's taxon label is in the annotations structure.

Effectively this swaps the loops around; rather than iterating over the
metadata and searching the tree for the node to label, we instead loop over
the tree just once, and check each node to see if there are any annotations
to be applied. This removes the need to search within the tree at all.

This has been tested in Cardiff. We have verfied that the md5sum of
the tree created before and after this commit are exactly the same.
On a recent COG-UK tree, this reduces compute time from 18500 seconds
to just 45 seconds.

Co-authored-by: Matt Bull <bullmj2@gmail.com>